### PR TITLE
fix offsets tuple error

### DIFF
--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -94,7 +94,8 @@ class Tool:
             self.gcode_z_offset if self.gcode_z_offset else 0.0,
         ]
 
-    def set_offset(self, [x, y, z]):
+    def set_offset(self, offsets):
+        x, y, z = offsets
         self.gcode_x_offset = x
         self.gcode_y_offset = y
         self.gcode_z_offset = z


### PR DESCRIPTION
I got an error when I used this branch:
def set_offset(self, [x, y, z]):
                              ^
SyntaxError: invalid syntax

The updated code uses the variable 'offsets' in the function def, then unpacks to x, y, z variables like before.